### PR TITLE
Fixed a bug in the way the kernel traverses through the file system

### DIFF
--- a/sources/kernel/src/fs/filesystem.cpp
+++ b/sources/kernel/src/fs/filesystem.cpp
@@ -83,7 +83,14 @@ void CFilesystem::Initialize()
             }
 
             tmpName[j] = '\0';
-            mpPtr += j + 1;
+            
+            mpPtr += j;
+
+            // jedna se o konec retezce?
+            if (mpPtr[0] != '\0')
+            {
+                mpPtr += 1;
+            }
 
             tmpNode = node->Find_Child(tmpName);
             // uzel jsme nasli - pouzijeme ho pro dalsi prohledavani
@@ -140,7 +147,14 @@ IFile* CFilesystem::Open(const char* path, NFile_Open_Mode mode)
         }
 
         tmpName[j] = '\0';
-        mpPtr += j + 1;
+        
+        mpPtr += j;
+
+        // jedna se o konec retezce?
+        if (mpPtr[0] != '\0')
+        {
+            mpPtr += 1;
+        }
 
         tmpNode = node->Find_Child(tmpName);
         if (tmpNode)


### PR DESCRIPTION
The current implementation assumes that there are at least two zero bytes (`\0`) at the end of each string literal. However, it may not always be the case as it is up to the compiler where it decides to place them.

For instance, if I use the following path names within the file system, the program works as expected.

```c++
const CFilesystem::TFS_Driver CFilesystem::gFS_Drivers[] = {
    { "GPIO_FS", "DEV:gpio", &fsGPIO_FS_Driver },
    { "MONITOR_FS", "DEV:monitor\0", &fsMonitor_FS_Driver },
};
```

However, if I drop the `\0` at the end of `"DEV:monitor\0"` the code will break as it attempts to further create a file `"GPIO_FS"`, which is stored right after `"DEV:monitor"` in memory. This can be verified by looking at the `.ELF` file using the following command `readelf kernel.elf -x.rodata`.

Case (1) - Code works

![02](https://github.com/MartinUbl/KIV-RTOS/assets/64095079/4442d053-e4f8-4387-8396-8b4b3c64c0ee)

Case (2) - Code does not work

![01](https://github.com/MartinUbl/KIV-RTOS/assets/64095079/4f240754-8aa9-48a7-9f64-7bb9f2f9b5ba)

I first check if the loop was terminated due to `\0` and if so, I will NOT skip the `:` or `/` character as it is simply not there. Hopefully this solves the issue.