### PR TITLE
Prohodit drivery pro mutex a semafor v tabulce FS driverů

### DIFF
--- a/sources/kernel/src/fs/filesystem_drivers.cpp
+++ b/sources/kernel/src/fs/filesystem_drivers.cpp
@@ -23,8 +23,8 @@ const CFilesystem::TFS_Driver CFilesystem::gFS_Drivers[] = {
     { "OLED_Disp_FS", "DEV:oled", &fsOLED_Display_FS_Driver },
 
     // virtualni zarizeni
-    { "Mutex", "SYS:mtx", &fsSemaphore_FS_Driver },
-    { "Semaphore", "SYS:sem", &fsMutex_FS_Driver },
+    { "Mutex", "SYS:mtx", &fsMutex_FS_Driver },
+    { "Semaphore", "SYS:sem", &fsSemaphore_FS_Driver },
     { "CondVar", "SYS:cv", &fsCond_Var_FS_Driver },
     { "Pipe", "SYS:pipe", &fsPipe_FS_Driver },
 };


### PR DESCRIPTION
v tabulce filesystem driverů v filesystem_drivers.cpp, záznamy s cestou na virtuální zařízení pro mutexy (SYS:mtx) a semafory (SYS:sem) odkazovaly na špatnou instanci driveru. SYS:mtx odkazoval na driver pro semafor a vice versa.

nahradit:
```cpp
{ "Mutex", "SYS:mtx", &fsSemaphore_FS_Driver },
{ "Semaphore", "SYS:sem", &fsMutex_FS_Driver },
```
za:
```cpp
{ "Mutex", "SYS:mtx", &fsMutex_FS_Driver },
{ "Semaphore", "SYS:sem", &fsSemaphore_FS_Driver },
```