### PR TITLE
Oprava SWI nečasovaného přerušitelného spánku

### DIFF
--- a/sources/kernel/src/process/process_manager.cpp
+++ b/sources/kernel/src/process/process_manager.cpp
@@ -272,7 +272,7 @@ void CProcess_Manager::Handle_Process_SWI(NSWI_Process_Service svc_idx, uint32_t
             mCurrent_Task_Node->task->sched_counter = 1;
             mCurrent_Task_Node->task->state = NTask_State::Interruptable_Sleep;
             mCurrent_Task_Node->task->notified_deadline = r1;
-            mCurrent_Task_Node->task->sleep_timer = sTimer.Get_Tick_Count() + ( (r0 == Indefinite) ? r0 + 1 : r0 );
+            mCurrent_Task_Node->task->sleep_timer =  ( (r0 == Indefinite) ? r0 : sTimer.Get_Tick_Count() + r0 );
             Schedule();
             break;
         case NSWI_Process_Service::Get_Sched_Info:


### PR DESCRIPTION
Při volání SWI sleep s hodnotou doby pro spánek, která odpovídá "nekonečně dlouho", byla tato hodnota špatně přiřazena do struktury procesu.

Původní přiřazení ` mCurrent_Task_Node->task->sleep_timer = sTimer.Get_Tick_Count() + ( (r0 == Indefinite) ? r0 + 1 : r0 );` při `r0=Indefinite` nastavovalo `sleep_timer` na hodnotu aktuálního počtu tiků časovače (`r0+1 == 0`). Při volání `Schedule()` po přerušení od časovače by se tedy právě uspaný proces opět probudil, jelikož počet tiků by byl větší než ten uložený:

```c++
void CProcess_Manager::Schedule()
{
    // projdeme vsechny uspane (sleep) procesy, zda je na case je vzbudit
    {
        CProcess_List_Node* node = mProcess_List_Head;
        while (node)
        {
            if (node->task->state == NTask_State::Interruptable_Sleep)
            {
                // problém zde: sleep_timer při aktuálním přiřazení ve SWI sleep nikdy není Indefinite
                if (node->task->sleep_timer != Indefinite && node->task->sleep_timer <= sTimer.Get_Tick_Count())
                    Notify_Process(node->task);
            }

            node = node->next;
        }
    }
(...)
```

Tento commit nastavuje `sleep_timer` na správnou hodnotu.
