### PR TITLE
CPageManager::Free_Page -- oprava výpočtu indexu stránky

### DIFF
--- a/sources/kernel/src/memory/pages.cpp
+++ b/sources/kernel/src/memory/pages.cpp
@@ -54,5 +54,5 @@ void CPage_Manager::Free_Page(uint32_t fa)
 {
     // pro vyssi bezpecnost v nejakych safe systemech lze tady data stranky premazavat napr. nulami po dealokaci
 
-    Mark(fa / mem::PageSize - LowMemoryPhys, false);
+    Mark( (fa - LowMemoryPhys) / mem::PageSize, false);
 }

--- a/sources/kernel/src/memory/pages.cpp
+++ b/sources/kernel/src/memory/pages.cpp
@@ -49,9 +49,10 @@ uint32_t CPage_Manager::Alloc_Page()
     return 0;
 }
 
+constexpr uint32_t LowMemoryPhys = mem::LowMemory - mem::MemoryVirtualBase;
 void CPage_Manager::Free_Page(uint32_t fa)
 {
     // pro vyssi bezpecnost v nejakych safe systemech lze tady data stranky premazavat napr. nulami po dealokaci
 
-    Mark(fa / mem::PageSize, false);
+    Mark(fa / mem::PageSize - LowMemoryPhys, false);
 }


### PR DESCRIPTION
`Free_Page `označí stránku (rámec) na dané fyz. adrese jako volnou. Fyz. adresu je nutno převést na index do bitmapy stránek. Výpočet indexu byl chybný.

Rámce v paměti začínáme alokovat od adresy `0xC1000000` (v adresním prostoru kernelu), což fyzicky odpovídá adrese `0x01000000` (`LowMemoryPhys`). Tudíž první alokovatelný rámec začíná na této adrese. Tento první rámec zároveň odpovídá prvnímu bitu v bitmapě volných rámců (`CPage_Manager::mPage_Bitmap`). Ovšem výpočtem ve `Free_Page `bychom pro první rámec dostali index 16 (`= 0x01000000/mem::PageSize`). Fyzickou adresu je tedy potřeba offsetnout o oněch `0x01000000`, aby výpočet vycházel správně.