### PR TITLE
Enable_IRQ: oprava registru

### DIFF
--- a/sources/kernel/src/interrupt_controller.cpp
+++ b/sources/kernel/src/interrupt_controller.cpp
@@ -84,7 +84,7 @@ void CInterrupt_Controller::Enable_IRQ(hal::IRQ_Source source_idx)
 {
     const unsigned int idx_base = static_cast<unsigned int>(source_idx);
 
-    Regs(idx_base < 32 ? hal::Interrupt_Controller_Reg::IRQ_Enable_1 : hal::Interrupt_Controller_Reg::IRQ_Enable_1) = (1 << (idx_base % 32));
+    Regs(idx_base < 32 ? hal::Interrupt_Controller_Reg::IRQ_Enable_1 : hal::Interrupt_Controller_Reg::IRQ_Enable_2) = (1 << (idx_base % 32));
 }
 
 void CInterrupt_Controller::Disable_IRQ(hal::IRQ_Source source_idx)


### PR DESCRIPTION
Na obou stranách ternárního operátoru byl registr IRQ_Enable_1, ale při vyhodnocení podmíny jako false se má použít registr IRQ_Enable_2 (pro přerušení s indexem 32-63).