### PR TITLE
Fixing Mutex and Semaphores

### DIFF
--- a/sources/kernel/include/fs/drivers/semaphore_fs.h
+++ b/sources/kernel/include/fs/drivers/semaphore_fs.h
@@ -32,7 +32,7 @@ class CSemaphore_FS_Driver : public IFilesystem_Driver
                 {
                     semname[i] = '\0';
                     // explicitne receno, ze nevime, kolik zdroju ma semafor mit
-                    if (semname[i + 1 == '?'])
+                    if (semname[i + 1] == '?')
                         break;
 
                     rescnt = atoi(&semname[i + 1]);

--- a/sources/stdlib/src/stdmutex.cpp
+++ b/sources/stdlib/src/stdmutex.cpp
@@ -8,8 +8,8 @@ static const char Sem_File_Prefix[] = "SYS:sem/";
 mutex_t mutex_create(const char* name)
 {
     char mtxfile[64];
-    strncpy(mtxfile, Mutex_File_Prefix, sizeof(Mutex_File_Prefix));
-    strncpy(mtxfile + sizeof(Mutex_File_Prefix), name, sizeof(mtxfile) - sizeof(Mutex_File_Prefix) - 1);
+    strncpy(mtxfile, Mutex_File_Prefix, sizeof(Mutex_File_Prefix) - 1);
+    strncpy(mtxfile + sizeof(Mutex_File_Prefix) - 1, name, sizeof(mtxfile) - sizeof(Mutex_File_Prefix) - 1);
 
     mutex_t mtx = static_cast<mutex_t>(open(mtxfile, NFile_Open_Mode::Read_Write));
 
@@ -38,8 +38,8 @@ void mutex_destroy(mutex_t mtx)
 semaphore_t sem_create(const char* name)
 {
     char semfile[64];
-    strncpy(semfile, Sem_File_Prefix, sizeof(Sem_File_Prefix));
-    strncpy(semfile + sizeof(Sem_File_Prefix), name, sizeof(semfile) - sizeof(Sem_File_Prefix) - 1);
+    strncpy(semfile, Sem_File_Prefix, sizeof(Sem_File_Prefix) - 1);
+    strncpy(semfile + sizeof(Sem_File_Prefix) - 1, name, sizeof(semfile) - sizeof(Sem_File_Prefix) - 1);
 
     semaphore_t sem = static_cast<semaphore_t>(open(semfile, NFile_Open_Mode::Read_Write));
 

--- a/sources/stdlib/src/stdmutex.cpp
+++ b/sources/stdlib/src/stdmutex.cpp
@@ -8,7 +8,7 @@ static const char Sem_File_Prefix[] = "SYS:sem/";
 mutex_t mutex_create(const char* name)
 {
     char mtxfile[64];
-    strncpy(mtxfile, Mutex_File_Prefix, sizeof(Mutex_File_Prefix) - 1);
+    strncpy(mtxfile, Mutex_File_Prefix, sizeof(Mutex_File_Prefix));
     strncpy(mtxfile + sizeof(Mutex_File_Prefix) - 1, name, sizeof(mtxfile) - sizeof(Mutex_File_Prefix) - 1);
 
     mutex_t mtx = static_cast<mutex_t>(open(mtxfile, NFile_Open_Mode::Read_Write));
@@ -38,7 +38,7 @@ void mutex_destroy(mutex_t mtx)
 semaphore_t sem_create(const char* name)
 {
     char semfile[64];
-    strncpy(semfile, Sem_File_Prefix, sizeof(Sem_File_Prefix) - 1);
+    strncpy(semfile, Sem_File_Prefix, sizeof(Sem_File_Prefix));
     strncpy(semfile + sizeof(Sem_File_Prefix) - 1, name, sizeof(semfile) - sizeof(Sem_File_Prefix) - 1);
 
     semaphore_t sem = static_cast<semaphore_t>(open(semfile, NFile_Open_Mode::Read_Write));


### PR DESCRIPTION
- Fixed copying prefix `SYS:sem/` in `semaphore_create()`. It was copied including null terminator disregarding anything after it. (`sizeof("literal")` includes `\0`)
- Bracket fix in `semaphore_fs`