### PR TITLE
Fixed pipe bugs

### DIFF
--- a/sources/kernel/include/fs/drivers/pipe_fs.h
+++ b/sources/kernel/include/fs/drivers/pipe_fs.h
@@ -7,41 +7,35 @@
 #include <process/resource_manager.h>
 
 // driver pro filesystem pro roury
-class CPipe_FS_Driver : public IFilesystem_Driver
-{
-	public:
-		virtual void On_Register() override
-        {
-            //
-        }
+class CPipe_FS_Driver : public IFilesystem_Driver {
+public:
+    virtual void On_Register() override {
+        //
+    }
 
-        virtual IFile* Open_File(const char* path, NFile_Open_Mode mode) override
-        {
-            // SYS:pipe/roura#16
-            // SYS:pipe/roura#?
-            // SYS:pipe/roura
+    virtual IFile *Open_File(const char *path, NFile_Open_Mode mode) override {
+        // SYS:pipe/roura#16
+        // SYS:pipe/roura#?
+        // SYS:pipe/roura
+        char pipename[Max_Pipe_Name_Length];
+        strncpy(pipename, path, Max_Pipe_Name_Length);
 
-            /*char pipename[Max_Pipe_Name_Length];
-            strncpy(pipename, path, Max_Pipe_Name_Length);
-
-            const int len = strlen(pipename);
-            uint32_t pipesize = Pipe_Byte_Count_Unknown;
-            for (int i = 1; i < len - 1; i++)
-            {
-                if (pipename[i] == '#')
-                {
-                    pipename[i] = '\0';
-                    // explicitne receno, ze nevime, jak velka ma pipe byt
-                    if (pipename[i + 1 == '?'])
-                        break;
-
-                    pipesize = atoi(&pipename[i + 1]);
+        const int len = strlen(pipename);
+        uint32_t pipesize = Pipe_Byte_Count_Unknown;
+        for (int i = 1; i < len - 1; i++) {
+            if (pipename[i] == '#') {
+                pipename[i] = '\0';
+                // explicitne receno, ze nevime, jak velka ma pipe byt
+                if (pipename[i + 1] == '?')
                     break;
-                }
-            }*/
 
-            return sProcess_Resource_Manager.Alloc_Pipe("roura", 32/*pipename, pipesize*/);
+                pipesize = atoi(&pipename[i + 1]);
+                break;
+            }
         }
+
+        return sProcess_Resource_Manager.Alloc_Pipe(pipename, pipesize);
+    }
 };
 
 CPipe_FS_Driver fsPipe_FS_Driver;

--- a/sources/stdlib/src/stdfile.cpp
+++ b/sources/stdlib/src/stdfile.cpp
@@ -166,10 +166,11 @@ const char Pipe_File_Prefix[] = "SYS:pipe/";
 uint32_t pipe(const char* name, uint32_t buf_size)
 {
     char fname[64];
+    int name_len = strlen(name);
     strncpy(fname, Pipe_File_Prefix, sizeof(Pipe_File_Prefix));
-    strncpy(fname + sizeof(Pipe_File_Prefix), name, sizeof(fname) - sizeof(Pipe_File_Prefix) - 1);
-
-    int ncur = sizeof(Pipe_File_Prefix) + strlen(name);
+    strncpy(fname + sizeof(Pipe_File_Prefix) - 1, name, name_len);
+    
+    int ncur = sizeof(Pipe_File_Prefix) + name_len - 1;
 
     fname[ncur++] = '#';
 


### PR DESCRIPTION
# pipe_fs.h
- Fixed pipe filesystem driver: `/sources/kernel/include/fs/drivers/pipe_fs.h`
- The driver now correctly creates a pipe of given name and size instead of using hardcoded values 
# stdfile.h
- Fixed string concatenation bug in the `pipe()` function where null terminator was incorrectly inserted between the pipe prefix and pipe name

